### PR TITLE
in the swap case, it counts the frequency in the correct text and not…

### DIFF
--- a/training/train_error_model.py
+++ b/training/train_error_model.py
@@ -107,7 +107,7 @@ class ErrorModel:
                     if re.search(r'swap\_', spell_err[0]):
                         correct_i =  spell_err[0][6]
                         correct_i1 = spell_err[0][5]
-                        self.cm_rev[correct_i + correct_i1] += 1
+                        self.cm_rev[correct_i1 + correct_i] += 1
                         self.num_swap_errors += 1
                     elif re.search(r's\_', spell_err[0]):
                         # typo
@@ -163,7 +163,7 @@ class ErrorModel:
                       + edit_key.encode('utf-8') +']/bigram['+ edit_key.encode('utf-8') + '],\t' \
                       + repr(self.cm_rev[edit_key]) + '/' + repr(self.biletter_count[edit_key]) + ')'
         for edit_key in self.cm_sub:
-            denom_key = edit_key[1]
+            denom_key = edit_key[0]
             if float(self.letter_count[denom_key]) != 0.0:
                 err_prob = self.cm_sub[edit_key] / float(self.letter_count[denom_key])
                 err_logprob = -math.log10(err_prob)


### PR DESCRIPTION
… in the erroreneous text. Also, in the substitution case, the file does not finds the probability from the corpora but from the correct words.